### PR TITLE
Python script to extract wikipedia article summary from the page_name

### DIFF
--- a/wiki_summary_segmentation.py
+++ b/wiki_summary_segmentation.py
@@ -1,0 +1,18 @@
+import json, pprint
+
+pp = pprint.PrettyPrinter(indent=4)
+fname = '/home/sampanna/Downloads/wiki_86.json'
+
+with open(fname) as f:
+    content = f.readlines()
+# you may also want to remove whitespace characters like `\n` at the end of each line
+content = [x.strip() for x in content]
+
+firstLine = json.loads(content[0])
+print pp.pprint(firstLine)
+
+text = firstLine['text']
+
+tokens = text.split('\n\n')
+
+print tokens[1]


### PR DESCRIPTION
### What does this script do?
1. Given a page Id, hit the wikipedia API to get the json response for that page.
2. Fetch the wikitext corresponding to the summary by walking over the json response tree.
3. Filter the regex of the wikitext to convert it to human-readable plain text.

### Pending improvements:
1. Add functionality to read page_names from txt file and hit the APIs for each in a loop.
2. Making it multithreaded for better speed for large scale parsing.